### PR TITLE
fix: eliminate the error log of merged event

### DIFF
--- a/pkg/webhook/events.go
+++ b/pkg/webhook/events.go
@@ -355,6 +355,7 @@ func actionRelatesToPullRequestComment(action scm.Action, l *logrus.Entry) bool 
 		scm.ActionLabel,
 		scm.ActionUnlabel,
 		scm.ActionClose,
+		scm.ActionMerge,
 		scm.ActionReopen,
 		scm.ActionSync:
 		return false


### PR DESCRIPTION
fix: eliminate the error log of merged event